### PR TITLE
Enable user management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,26 @@ Este proyecto es un frontend sencillo para consumir el backend del inventario di
 2. Instala las dependencias con `npm install`.
 3. Ejecuta el entorno de desarrollo con `npm run dev`.
 
+### Instalación en macOS
+
+1. Instala [Node.js](https://nodejs.org/) que incluye npm. Puedes usar Homebrew
+   con `brew install node`.
+2. En la raíz del proyecto ejecuta `npm install` para descargar las dependencias
+   (incluyendo Vite, Tailwind y Material UI).
+3. Copia el archivo `.env.example` a `.env` y ajusta `VITE_API_BASE_URL` con la
+   URL de tu backend.
+4. Inicia la aplicación con `npm run dev` y abre `http://localhost:5173` en tu
+   navegador.
+
+Las dependencias de estilos (Tailwind y Material UI) se cargan desde CDN para
+facilitar la configuración.
+
 ## Estructura
 
 - `index.html` punto de entrada de la aplicación.
 - `src/` contiene los componentes de React.
 - `vite.config.js` configuración mínima de Vite.
 
-El componente `ProductList` obtiene los productos desde `${VITE_API_BASE_URL}/products`.
+En la pantalla principal puedes administrar productos, inventario y usuarios.
+
+Los componentes `ProductList` y `UserList` obtienen la información desde `${VITE_API_BASE_URL}`.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BAS Inventory Frontend</title>
+    <!-- Tailwind CSS via CDN -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <!-- Material UI via CDN -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+    <script src="https://unpkg.com/@mui/material@5.15.12/umd/material-ui.development.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import React, { useRef } from 'react';
 import ProductForm from './components/ProductForm';
 import ProductList from './components/ProductList';
+import InventoryForm from './components/InventoryForm';
+import UserForm from './components/UserForm';
+import UserList from './components/UserList';
 
 export default function App() {
   const listRef = useRef();
@@ -9,10 +12,15 @@ export default function App() {
   const [refresh, setRefresh] = React.useState(false);
 
   return (
-    <div>
-      <h1>Productos</h1>
+    <div className="container mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Productos</h1>
       <ProductForm onProductAdded={() => setRefresh(r => !r)} />
       <ProductList key={refresh} />
+      <h2 className="text-xl font-bold">Movimiento de Inventario</h2>
+      <InventoryForm />
+      <h2 className="text-xl font-bold">Usuarios</h2>
+      <UserForm onUserAdded={() => setRefresh(r => !r)} />
+      <UserList key={`users-${refresh}`} />
     </div>
   );
 }

--- a/src/components/InventoryForm.jsx
+++ b/src/components/InventoryForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
 
 export default function InventoryForm() {
   const [form, setForm] = useState({ productoId: '', cantidad: 0 });
@@ -24,21 +25,23 @@ export default function InventoryForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
-      <input
+    <form onSubmit={handleSubmit} className="space-y-2 mb-4">
+      <TextField
+        label="ID Producto"
         name="productoId"
-        placeholder="ID Producto"
         value={form.productoId}
         onChange={handleChange}
+        fullWidth
       />
-      <input
+      <TextField
+        label="Cantidad"
         name="cantidad"
         type="number"
-        placeholder="Cantidad"
         value={form.cantidad}
         onChange={handleChange}
+        fullWidth
       />
-      <button type="submit">Agregar</button>
+      <Button variant="contained" type="submit">Agregar</Button>
     </form>
   );
 }

--- a/src/components/ProductForm.jsx
+++ b/src/components/ProductForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
 
 export default function ProductForm({ onProductAdded }) {
   const [form, setForm] = useState({ nombre: '', descripcion: '', precio: '', stock: '' });
@@ -26,38 +27,42 @@ export default function ProductForm({ onProductAdded }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
-      <input
+    <form onSubmit={handleSubmit} className="space-y-2 mb-4">
+      <TextField
+        label="Nombre"
         name="nombre"
         value={form.nombre}
         onChange={handleChange}
-        placeholder="Nombre del producto"
+        fullWidth
         required
       />
-      <input
+      <TextField
+        label="Descripción"
         name="descripcion"
         value={form.descripcion}
         onChange={handleChange}
-        placeholder="Descripción"
+        fullWidth
         required
       />
-      <input
+      <TextField
+        label="Precio"
         name="precio"
         type="number"
         value={form.precio}
         onChange={handleChange}
-        placeholder="Precio"
+        fullWidth
         required
       />
-      <input
+      <TextField
+        label="Stock"
         name="stock"
         type="number"
         value={form.stock}
         onChange={handleChange}
-        placeholder="Stock"
+        fullWidth
         required
       />
-      <button type="submit">Agregar Producto</button>
+      <Button variant="contained" type="submit">Agregar Producto</Button>
     </form>
   );
 }

--- a/src/components/ProductList.jsx
+++ b/src/components/ProductList.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { TextField, Button } from '@mui/material';
 
 export default function ProductList() {
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState(null);
-  const [editName, setEditName] = useState('');
+  const [editForm, setEditForm] = useState({ nombre: '', descripcion: '', precio: '', stock: '' });
 
   const fetchProducts = () => {
     const baseUrl = import.meta.env.VITE_API_BASE_URL;
@@ -32,7 +33,17 @@ export default function ProductList() {
 
   const handleEdit = (product) => {
     setEditingId(product.id);
-    setEditName(product.nombre);
+    setEditForm({
+      nombre: product.nombre,
+      descripcion: product.descripcion,
+      precio: product.precio,
+      stock: product.stock,
+    });
+  };
+
+  const handleEditChange = (e) => {
+    const { name, value } = e.target;
+    setEditForm((prev) => ({ ...prev, [name]: value }));
   };
 
   const handleEditSubmit = async (e) => {
@@ -41,10 +52,15 @@ export default function ProductList() {
     await fetch(`${baseUrl}/api/productos/${editingId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nombre: editName }),
+      body: JSON.stringify({
+        nombre: editForm.nombre,
+        descripcion: editForm.descripcion,
+        precio: Number(editForm.precio),
+        stock: Number(editForm.stock),
+      }),
     });
     setEditingId(null);
-    setEditName('');
+    setEditForm({ nombre: '', descripcion: '', precio: '', stock: '' });
     fetchProducts();
   };
 
@@ -53,31 +69,63 @@ export default function ProductList() {
   }
 
   return (
-    <ul>
+    <ul className="space-y-4">
       {products.map((p) => (
-        <li key={p.id}>
+        <li key={p.id} className="border p-4 rounded-md">
           {editingId === p.id ? (
-            <form onSubmit={handleEditSubmit} style={{ display: 'inline' }}>
-              <input
-                value={editName}
-                onChange={e => setEditName(e.target.value)}
+            <form onSubmit={handleEditSubmit} className="space-y-2">
+              <TextField
+                label="Nombre"
+                name="nombre"
+                value={editForm.nombre}
+                onChange={handleEditChange}
+                fullWidth
                 required
               />
-              <button type="submit">Guardar</button>
-              <button type="button" onClick={() => setEditingId(null)}>Cancelar</button>
+              <TextField
+                label="Descripción"
+                name="descripcion"
+                value={editForm.descripcion}
+                onChange={handleEditChange}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Precio"
+                name="precio"
+                type="number"
+                value={editForm.precio}
+                onChange={handleEditChange}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Stock"
+                name="stock"
+                type="number"
+                value={editForm.stock}
+                onChange={handleEditChange}
+                fullWidth
+                required
+              />
+              <div className="flex space-x-2">
+                <Button variant="contained" type="submit">Guardar</Button>
+                <Button variant="outlined" type="button" onClick={() => setEditingId(null)}>Cancelar</Button>
+              </div>
             </form>
           ) : (
-            <>
-              <strong>{p.nombre}</strong> - {p.descripcion} 
-              <br />
-              Precio: ${p.precio} | Stock: {p.stock}
-              <br />
-              <button onClick={() => handleEdit(p)}>Editar</button>
-              <button onClick={() => handleDelete(p.id)}>Eliminar</button>
-            </>
-          )}
+            <div className="space-y-1">
+              <div className="font-bold">{p.nombre}</div>
+              <div>{p.descripcion}</div>
+              <div className="text-sm">Precio: ${p.precio} | Stock: {p.stock}</div>
+              <div className="space-x-2">
+                <Button size="small" variant="outlined" onClick={() => handleEdit(p)}>Editar</Button>
+                <Button size="small" variant="outlined" color="error" onClick={() => handleDelete(p.id)}>Eliminar</Button>
+              </div>
+            </div>
+          )
         </li>
-      ))}
+        ))}
     </ul>
   );
 }

--- a/src/components/UserForm.jsx
+++ b/src/components/UserForm.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
+
+export default function UserForm({ onUserAdded }) {
+  const [form, setForm] = useState({ nombre: '', email: '' });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    await fetch(`${baseUrl}/api/usuarios`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nombre: form.nombre, email: form.email }),
+    });
+    setForm({ nombre: '', email: '' });
+    onUserAdded && onUserAdded();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 mb-4">
+      <TextField
+        label="Nombre"
+        name="nombre"
+        value={form.nombre}
+        onChange={handleChange}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Email"
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+        type="email"
+        fullWidth
+        required
+      />
+      <Button variant="contained" type="submit">Agregar Usuario</Button>
+    </form>
+  );
+}

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { TextField, Button } from '@mui/material';
+
+export default function UserList() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState(null);
+  const [editForm, setEditForm] = useState({ nombre: '', email: '' });
+
+  const fetchUsers = () => {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    fetch(`${baseUrl}/api/usuarios`)
+      .then(res => res.json())
+      .then(data => {
+        setUsers(data);
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error('Error consultando usuarios', err);
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleDelete = async (id) => {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    await fetch(`${baseUrl}/api/usuarios/${id}`, { method: 'DELETE' });
+    fetchUsers();
+  };
+
+  const handleEdit = (user) => {
+    setEditingId(user.id);
+    setEditForm({ nombre: user.nombre, email: user.email });
+  };
+
+  const handleEditChange = (e) => {
+    const { name, value } = e.target;
+    setEditForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleEditSubmit = async (e) => {
+    e.preventDefault();
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    await fetch(`${baseUrl}/api/usuarios/${editingId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(editForm),
+    });
+    setEditingId(null);
+    setEditForm({ nombre: '', email: '' });
+    fetchUsers();
+  };
+
+  if (loading) return <p>Cargando...</p>;
+
+  return (
+    <ul className="space-y-4">
+      {users.map(u => (
+        <li key={u.id} className="border p-4 rounded-md">
+          {editingId === u.id ? (
+            <form onSubmit={handleEditSubmit} className="space-y-2">
+              <TextField
+                label="Nombre"
+                name="nombre"
+                value={editForm.nombre}
+                onChange={handleEditChange}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Email"
+                name="email"
+                type="email"
+                value={editForm.email}
+                onChange={handleEditChange}
+                fullWidth
+                required
+              />
+              <div className="flex space-x-2">
+                <Button variant="contained" type="submit">Guardar</Button>
+                <Button variant="outlined" type="button" onClick={() => setEditingId(null)}>Cancelar</Button>
+              </div>
+            </form>
+          ) : (
+            <div className="space-y-1">
+              <div className="font-bold">{u.nombre}</div>
+              <div>{u.email}</div>
+              <div className="space-x-2">
+                <Button size="small" variant="outlined" onClick={() => handleEdit(u)}>Editar</Button>
+                <Button size="small" variant="outlined" color="error" onClick={() => handleDelete(u.id)}>Eliminar</Button>
+              </div>
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add UserForm and UserList components using Material UI
- integrate user management in main screen alongside products and inventory
- document that Tailwind/MUI are loaded via CDN and mention new user features

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a95bba0832d89607823064a671d